### PR TITLE
Fix for TypeError in invokable components

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -52,7 +52,7 @@ abstract class Component
         // For some reason Octane doesn't play nice with the injected $route.
         // We need to override it here. However, we can't remove the actual
         // param from the method signature as it would break inheritance.
-        $route = request()->route();
+        $route = request()->route() ?? $route;
 
         try {
             $componentParams = (new ImplicitRouteBinding($container))


### PR DESCRIPTION
When testing invokable components with PHPUnit (for example, `$this->actingAs($user)->get(route('component'))`), a `TypeError` occurs.
This is because `request()->route()` is `null`.

To fix this, we override `$route` only if `request()->route()` is not null